### PR TITLE
Adding ObjectTransformations capability to OntologyMapper

### DIFF
--- a/.github/pull_request_assignment.yml
+++ b/.github/pull_request_assignment.yml
@@ -4,5 +4,4 @@
       - ".github/**"
       - "SmartPlaces.Facilities/**"
     reviewers:
-      - "Tyler-Angell"
-      - "hammar"
+      - "joebeernink"

--- a/.github/workflows/SmartPlaces_Facilities.yml
+++ b/.github/workflows/SmartPlaces_Facilities.yml
@@ -33,11 +33,3 @@ jobs:
     - name: Test
       shell: pwsh
       run: "& ./.github/workflows/scripts/test.ps1"
-
-    - name: Trigger internal validations
-      if: ${{ inputs.build-type != ''}}
-      uses: Azure/pipelines@v1.2
-      with:
-        azure-devops-project-url: https://dev.azure.com/dynamicscrm/Solutions
-        azure-pipeline-name: '${{ inputs.build-type }}'
-        azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}

--- a/.github/workflows/SmartPlaces_Facilities_Main.yml
+++ b/.github/workflows/SmartPlaces_Facilities_Main.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    uses: 'Azure/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities.yml@main'
+    uses: 'WillowInc/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities.yml@main'
     with:
       build-type: 'Main Official (ASPEN)'
     secrets: inherit

--- a/.github/workflows/SmartPlaces_Facilities_Main_Willow.yml
+++ b/.github/workflows/SmartPlaces_Facilities_Main_Willow.yml
@@ -15,11 +15,14 @@ env:
 
 jobs:
 
-  - uses: 'WillowInc/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities.yml@main'
+  prep:
+    uses: 'WillowInc/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities.yml@main'
     with:
       build-type: 'Main Official (ASPEN)'
+    secrets: inherit
   
   build:
+    runs-on: windows-latest
     steps:
 
     - name: Package

--- a/.github/workflows/SmartPlaces_Facilities_Main_Willow.yml
+++ b/.github/workflows/SmartPlaces_Facilities_Main_Willow.yml
@@ -1,0 +1,31 @@
+name: Trigger Package Generation
+
+on:
+  pull_request:
+    branches: [
+      "main",
+    ]
+    paths: [
+      '.github/**',
+      'SmartPlaces.Facilities/**',
+    ]
+
+env: 
+  DOTNET_VERSION: '6.x' 
+
+jobs:
+
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+
+      - name: "build-force"
+        uses: 'WillowInc/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities.yml@main'
+        with:
+          build-type: 'Main Official (ASPEN)'
+
+      - name: Package
+        shell: pwsh
+        run: "& ./.github/workflows/scripts/buildandpack.ps1"

--- a/.github/workflows/SmartPlaces_Facilities_Main_Willow.yml
+++ b/.github/workflows/SmartPlaces_Facilities_Main_Willow.yml
@@ -1,7 +1,7 @@
 name: Trigger Package Generation
 
 on:
-  push:
+  pull_request:
     branches: [
       "main",
     ]

--- a/.github/workflows/SmartPlaces_Facilities_Main_Willow.yml
+++ b/.github/workflows/SmartPlaces_Facilities_Main_Willow.yml
@@ -1,7 +1,7 @@
 name: Trigger Package Generation
 
 on:
-  pull_request:
+  push:
     branches: [
       "main",
     ]
@@ -14,17 +14,8 @@ env:
   DOTNET_VERSION: '6.x' 
 
 jobs:
-
-  prep:
-    uses: 'WillowInc/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities.yml@main'
+  build:
+    uses: 'WillowInc/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities_Willow.yml@main'
     with:
       build-type: 'Main Official (ASPEN)'
     secrets: inherit
-  
-  build:
-    runs-on: windows-latest
-    steps:
-
-    - name: Package
-      shell: pwsh
-      run: "& ./.github/workflows/scripts/buildandpack.ps1"

--- a/.github/workflows/SmartPlaces_Facilities_Main_Willow.yml
+++ b/.github/workflows/SmartPlaces_Facilities_Main_Willow.yml
@@ -15,17 +15,13 @@ env:
 
 jobs:
 
+  - uses: 'WillowInc/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities.yml@main'
+    with:
+      build-type: 'Main Official (ASPEN)'
+  
   build:
-
-    runs-on: windows-latest
-
     steps:
 
-      - name: "build-force"
-        uses: 'WillowInc/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities.yml@main'
-        with:
-          build-type: 'Main Official (ASPEN)'
-
-      - name: Package
-        shell: pwsh
-        run: "& ./.github/workflows/scripts/buildandpack.ps1"
+    - name: Package
+      shell: pwsh
+      run: "& ./.github/workflows/scripts/buildandpack.ps1"

--- a/.github/workflows/SmartPlaces_Facilities_PR.yml
+++ b/.github/workflows/SmartPlaces_Facilities_PR.yml
@@ -15,4 +15,4 @@ env:
 
 jobs:
   build:
-    uses: 'Azure/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities.yml@main'
+    uses: 'WillowInc/opendigitaltwins-tools/.github/workflows/SmartPlaces_Facilities.yml@main'

--- a/.github/workflows/SmartPlaces_Facilities_Willow.yml
+++ b/.github/workflows/SmartPlaces_Facilities_Willow.yml
@@ -1,0 +1,39 @@
+name: SmartPlaces.Facilities Build
+
+on:
+  workflow_call:
+    inputs:
+      build-type:
+        required: false
+        type: string
+    secrets:
+      AZURE_DEVOPS_TOKEN:
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Restore dependencies
+      shell: pwsh
+      run: "& ./.github/workflows/scripts/restore.ps1"
+
+    - name: Build
+      shell: pwsh
+      run: "& ./.github/workflows/scripts/build.ps1"
+
+    - name: Test
+      shell: pwsh
+      run: "& ./.github/workflows/scripts/test.ps1"
+      
+    - name: Package
+      shell: pwsh
+      run: "& ./.github/workflows/scripts/buildandpack.ps1"

--- a/.github/workflows/scripts/buildandpack.ps1
+++ b/.github/workflows/scripts/buildandpack.ps1
@@ -1,0 +1,20 @@
+Set-StrictMode -Version latest
+$ErrorActionPreference = "Stop"
+Import-Module "$PSScriptRoot/common.psm1" -Force
+
+foreach($solution in $(Get-Solutions)) {
+    Write-Output "Building '$solution' using dotnet command line." 
+
+    push-location $(Split-Path $solution -Parent)
+        Show-SDKs
+
+        dotnet pack $solution --no-restore -c Release /bl:"$solution.build.binlog" "/flp1:errorsOnly;logfile=$solution.Errors.log"
+
+        if (! $?) {
+            $rawError = $(Get-Content -Raw "$solution.Errors.log")
+            Write-Error "Failed to build $solution. Error: $rawError"
+            pop-location
+            throw
+        }
+    pop-location
+}

--- a/SmartPlaces.Facilities/lib/OntologyMapper/README.md
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/README.md
@@ -16,6 +16,8 @@ This library provides helpers useful for mapping one Digital Twins Definition La
 1. Relationships
 1. Property Projections
 1. Backfilling of Properties
+1. Object Transformations
+
 
 A json file can be created with collections of these types of mappings, and then that can be used in a process which uses one DTDL ontology as an input and outputs a different DTDL ontology.
 
@@ -98,6 +100,18 @@ A collection of mappings from one or more property names to another property nam
 | OutputPropertyName | The name of the output property to assign the input property to |
 | InputPropertyNames | A collection of names of the input property to assign to the output property. Can only specify multiple input properties if the output property is a collection |
 | Priority | If there are multiple fillproperties for a single output property based on different DtmiFilters, priority is taken into account in ascending order |
+
+### ObjectTransformations
+
+In some cases, a property of the input model contains an object where one of the properties of that object needs to be put into a different field in the target model. A declaration can be made to map the input field to the appropriate output field.
+
+| Field | Description |
+| --- | --- |
+| OutputDtmiFilter | A regex filter which allows filtering so that the mapping is only applied to output property names which match the filter. ".*" to apply to all output properties |
+| OutputPropertyName | The name of the output property to assign the input property to |
+| InputProperty | The input property to use as the parent of the InputPropertyName |
+| InputPropertyName | The names of the input property to assign to the output property |
+| Priority | If there are multiple object transformations for a single output property based on different DtmiFilters, priority is taken into account in ascending order |
 
 ## Sample File
 

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/IOntologyMappingManager.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/IOntologyMappingManager.cs
@@ -65,5 +65,18 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
         /// <param name="propertyProjection">The property projection for the output property if there is one.</param>
         /// <returns>true if a mapping exists, false otherwise.</returns>
         public bool TryGetPropertyProjection(string outputDtmiFilter, string outputPropertyName, out PropertyProjection? propertyProjection);
+
+        /// <summary>
+        /// In some cases, a property of the input model contains an object where one of the properties of that object needs to be put into a different field in the target model. A declaration can be made to map the input field to the appropriate output field.
+        /// </summary>
+        /// <param name="outputDtmiFilter">A regex which describes which output dtmi's this rule applies to.</param>
+        /// <param name="outputPropertyName">The name of the output property.</param>
+        /// <param name="objectTransformation">The objectTransformation for the output property if there is one.</param>
+        /// <returns>
+        /// NoPropertyMatch (There is no match on the property passed in at all. No use testing further by type).
+        /// PropertyMatchOnly (There is a match on the property name, but not on the type. Try ancestors.
+        /// PropertyAndTypeMatch There is a match on the property name and the type. We have a match.
+        /// </returns>
+        public ObjectTransformationMatch TryGetObjectTransformation(string outputDtmiFilter, string outputPropertyName, out ObjectTransformation? objectTransformation);
     }
 }

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/ObjectTransformationMatch.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/ObjectTransformationMatch.cs
@@ -1,0 +1,29 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ObjectTransformationMatch.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
+{
+    /// <summary>
+    /// Indicates what type of match has occurred if any.
+    /// </summary>
+    public enum ObjectTransformationMatch
+    {
+        /// <summary>
+        /// There is no match on the property passed in at all. No use testing further by type
+        /// </summary>
+        NoPropertyMatch,
+
+        /// <summary>
+        /// There is a match on the property name, but not on the type. Try ancestors
+        /// </summary>
+        PropertyMatchOnly,
+
+        /// <summary>
+        /// There is a match on the property name and the type. We have a match
+        /// </summary>
+        PropertyAndTypeMatch,
+    }
+}

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapper.csproj
@@ -8,8 +8,8 @@
 		<Version>$(VersionPrefix)</Version>
 		<Authors>Microsoft</Authors>
 		<Description>Support for converting from one DTDL-based Ontology to a different DTDL Based Ontology</Description>
-		<AssemblyVersion>0.7.2</AssemblyVersion>
-		<PackageVersion>0.7.2-preview</PackageVersion>
+		<AssemblyVersion>0.7.5</AssemblyVersion>
+		<PackageVersion>0.7.5-preview</PackageVersion>
 		<RepositoryUrl>https://github.com/Azure/opendigitaltwins-tools</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/Azure/opendigitaltwins-tools/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapping.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMapping.cs
@@ -49,6 +49,13 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
         /// a chain of fields can be set here so that there is a priority list of fields that will backfill the name field if the input name field is null.
         /// </summary>
         public List<FillProperty> FillProperties { get; set; } = new List<FillProperty>();
+
+        /// <summary>
+        /// Gets or sets object transformations.
+        /// In some cases, the contents of one input property may be an object which needs to be transformed to a field in the target ontology. For instance, if
+        /// the target ontology requires that the unit field be a string, but the source property is an object, a transformation can be defined here to extract the unit field.
+        /// </summary>
+        public List<ObjectTransformation> ObjectTransformations { get; set; } = new List<ObjectTransformation>();
     }
 
     /// <summary>
@@ -190,6 +197,39 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
         /// Gets or sets the output namespace as a regex string.
         /// </summary>
         public string OutputNamespace { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Defines how to map one input property into a target property if the names don't match.
+    /// </summary>
+    public class ObjectTransformation
+    {
+        /// <summary>
+        /// Gets or sets a regex describing the output DTMI's targeted by this projection. ".*" for all.
+        /// </summary>
+        public string OutputDtmiFilter { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the name of the output property in the target ontology.
+        /// </summary>
+        public string OutputPropertyName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the input property in the source ontology that map to the target.
+        /// </summary>
+        public string InputProperty { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the input property name in the source ontology that map to the target.
+        /// </summary>
+        public string InputPropertyName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets projection priority.
+        /// If there are multiple projections for a single output property based on different DtmiFilters,
+        /// priority is taken into account in ascending order.
+        /// </summary>
+        public int Priority { get; set; } = 0;
     }
 
     /// <summary>

--- a/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMappingManager.cs
+++ b/SmartPlaces.Facilities/lib/OntologyMapper/src/OntologyMappingManager.cs
@@ -96,6 +96,27 @@ namespace Microsoft.SmartPlaces.Facilities.OntologyMapper
         }
 
         /// <inheritdoc/>
+        public ObjectTransformationMatch TryGetObjectTransformation(string outputDtmi, string outputPropertyName, out ObjectTransformation? objectTransformation)
+        {
+            var doesPropertyHaveTransformation = OntologyMapping.ObjectTransformations.Any(e => e.OutputPropertyName == outputPropertyName);
+
+            if (!doesPropertyHaveTransformation)
+            {
+                objectTransformation = null;
+                return ObjectTransformationMatch.NoPropertyMatch;
+            }
+
+            objectTransformation = OntologyMapping.ObjectTransformations.OrderBy(e => e.Priority).FirstOrDefault(e => e.OutputPropertyName == outputPropertyName && Regex.Match(outputDtmi, e.OutputDtmiFilter, RegexOptions.IgnoreCase).Success);
+
+            if (objectTransformation != null)
+            {
+                return ObjectTransformationMatch.PropertyAndTypeMatch;
+            }
+
+            return ObjectTransformationMatch.PropertyMatchOnly;
+        }
+
+        /// <inheritdoc/>
         public bool ValidateTargetOntologyMapping(IReadOnlyDictionary<Dtmi, DTEntityInfo> targetObjectModel, out List<string> invalidTargets)
         {
             invalidTargets = new List<string>();


### PR DESCRIPTION
### What
Adding ObjectTrasnformations capability to OntologyMapper

### Why
Need to be able to extract a value from a child object and set it in a string field on the parent object

### Tested
Added Unit tests
Updated the rest of the assemblies locally and tested with a linked version